### PR TITLE
Bump rode chart version

### DIFF
--- a/charts/rode/Chart.yaml
+++ b/charts/rode/Chart.yaml
@@ -4,7 +4,7 @@ name: rode
 maintainers:
   - name: Liatrio
     email: rode@liatrio.com
-version: 0.0.4
+version: 0.0.5
 appVersion: 0.0.1
 dependencies:
   - name: grafeas-elasticsearch


### PR DESCRIPTION
The [release job](https://github.com/rode/charts/runs/1914302633) failed because there's already a `rode-0.0.4` tag. 

This cuts a release for #16
