### PR TITLE
Updating grafeas-elasticsearch chart versions

### DIFF
--- a/charts/grafeas-elasticsearch/Chart.yaml
+++ b/charts/grafeas-elasticsearch/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 maintainers:
   - name: Liatrio
     email: rode@liatrio.com
-version: 0.0.6
-appVersion: 0.1.0
+version: 0.0.7
+appVersion: 0.3.0
 dependencies:
   - name: elasticsearch
     repository: https://helm.elastic.co

--- a/charts/grafeas-elasticsearch/values.yaml
+++ b/charts/grafeas-elasticsearch/values.yaml
@@ -7,7 +7,7 @@ secret:
 image:
   repository: ghcr.io/rode
   name: grafeas-elasticsearch
-  tag: v0.2.0
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: "grafeas-server"


### PR DESCRIPTION
Pulling the new version of the grafeas-elasticsearch helm chart and matching the app version