### PR TITLE
Patch bump for rode chart

### DIFF
--- a/charts/rode-ui/Chart.yaml
+++ b/charts/rode-ui/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 
 description: Web frontend for Rode
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.2.0

--- a/charts/rode-ui/Chart.yaml
+++ b/charts/rode-ui/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 
 description: Web frontend for Rode
 type: application
-version: 0.2.1
+version: 0.2.0
 appVersion: 0.2.0

--- a/charts/rode/Chart.yaml
+++ b/charts/rode/Chart.yaml
@@ -4,7 +4,7 @@ name: rode
 maintainers:
   - name: Liatrio
     email: rode@liatrio.com
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 dependencies:
   - name: rode-ui


### PR DESCRIPTION
In #30 we changed `charts/rode/ci/test-values.yaml` which seems to have triggered a release of the Rode chart; this fails because the [tag already exists](https://github.com/rode/charts/runs/2151700500?check_suite_focus=true#step:6:17). 

As a result, the `grafeas-elasticsearch` chart was released but not the `rode-ui` chart. 