### PR TITLE
Default image tag from chart app version for rode-ui

### DIFF
--- a/charts/rode-ui/templates/deployment.yaml
+++ b/charts/rode-ui/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" ($.Chart.AppVersion) ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: RODE_URL

--- a/charts/rode-ui/values.yaml
+++ b/charts/rode-ui/values.yaml
@@ -12,8 +12,6 @@ image:
   # Override once image is created
   repository: ghcr.io/rode/ui
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.2.0
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Changes the `rode-ui` chart to reference the chart app version for the image tag, if `image.tag` isn't set. This aligns it with the Rode chart and more importantly should trigger a release of the `rode-ui` chart. Follow up from #30, #31 