### PR TITLE
Force grafeas-elasticsearch release

### DIFF
--- a/charts/grafeas-elasticsearch/values.yaml
+++ b/charts/grafeas-elasticsearch/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 secret:
   enabled: false
 
-## Grafeas image version
+## grafeas-elasticsearch image version
 image:
   repository: ghcr.io/rode
   name: grafeas-elasticsearch


### PR DESCRIPTION
This [release job](https://github.com/rode/charts/runs/2151700500) from Friday partially succeeded for the `grafeas-elasticsearch` chart: it created the [GitHub release](https://github.com/rode/charts/releases/tag/grafeas-elasticsearch-0.2.0) but didn't update the chart repository's [index](https://github.com/rode/charts/blob/5504d759e15b87ce8c94e736981c2bc7991fe2d6/index.yaml#L3) on the `gh-pages` branch.

To trigger a new release, I think we need to do the following delete the [old release](https://github.com/rode/charts/releases/tag/grafeas-elasticsearch-0.2.0) and push a small change through, otherwise the chart releaser action won't detect any new charts to publish. 
