### PR TITLE
[rode] listen on single port for grpc / http

### DIFF
--- a/charts/rode/Chart.yaml
+++ b/charts/rode/Chart.yaml
@@ -4,8 +4,8 @@ name: rode
 maintainers:
   - name: Liatrio
     email: rode@liatrio.com
-version: 0.1.2
-appVersion: 0.1.1
+version: 0.2.0
+appVersion: 0.4.0
 dependencies:
   - name: rode-ui
     repository: https://rode.github.io/charts

--- a/charts/rode/templates/deployment.yaml
+++ b/charts/rode/templates/deployment.yaml
@@ -42,26 +42,24 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" ($.Chart.AppVersion) ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--http-port={{ .Values.container.httpPort }}"
-            - "--grpc-port={{ .Values.container.grpcPort }}"
+            - "--port={{ .Values.service.port }}"
             - "--grafeas-host={{ .Values.grafeas.host }}"
             - "--opa-host={{ .Values.opa.host }}"
             - "--elasticsearch-host={{ .Values.elasticsearch.host }}"
             - "--debug={{ .Values.debug }}"
           ports:
-            - containerPort: {{ .Values.container.httpPort }}
-            - containerPort: {{ .Values.container.grpcPort }}
+            - containerPort: {{ .Values.service.port }}
           {{- with .Values.extraEnv }}
           env:
 {{ toYaml . | indent 12 }}
           {{- end }}
           readinessProbe:
             exec:
-              command: ["/grpc_health_probe", "-addr=:{{ .Values.container.grpcPort }}"]
+              command: ["/grpc_health_probe", "-addr=:{{ .Values.service.port }}"]
             initialDelaySeconds: 5
           livenessProbe:
             exec:
-              command: ["/grpc_health_probe", "-addr=:{{ .Values.container.grpcPort }}"]
+              command: ["/grpc_health_probe", "-addr=:{{ .Values.service.port }}"]
             initialDelaySeconds: 5
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/rode/templates/service.yaml
+++ b/charts/rode/templates/service.yaml
@@ -13,17 +13,10 @@ spec:
     app: {{ template "rode.name" . }}
     release: {{ .Release.Name }}
   ports:
-    - port: {{ .Values.service.grpc.port }}
-      targetPort: {{ .Values.container.grpcPort }}
-      {{- if and (eq .Values.service.grpc.type "NodePort") (.Values.service.grpc.nodePort) }}
-      nodePort: {{ .Values.service.grpc.nodePort }}
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       protocol: TCP
-      name: rode-grpc
-    - port: {{ .Values.service.http.port }}
-      targetPort: {{ .Values.container.httpPort }}
-      {{- if and (eq .Values.service.http.type "NodePort") (.Values.service.http.nodePort) }}
-      nodePort: {{ .Values.service.http.nodePort }}
-      {{- end }}
-      protocol: TCP
-      name: rode-http
+      name: rode

--- a/charts/rode/values.yaml
+++ b/charts/rode/values.yaml
@@ -34,16 +34,9 @@ image:
 
 extraEnv: []
 
-container:
-  grpcPort: 50051
-  httpPort: 50052
 service:
-  grpc:
-    type: ClusterIP
-    port: 50051
-  http:
-    type: ClusterIP
-    port: 50052
+  type: ClusterIP
+  port: 50051
 
 tolerations: []
 affinity: {}


### PR DESCRIPTION
depends on https://github.com/rode/rode/pull/54 and a new release (`v0.4.0`)