### PR TITLE
Add k8s-enforcer chart

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,5 +67,5 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Test install collectors teardown
-        run: install-test-collectors-enforcers-teardown
+        run: make install-test-collectors-enforcers-teardown
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,14 +58,14 @@ jobs:
         run: make install-test-rode-ui
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Test install collectors setup
-        run: make install-test-collectors-setup
+      - name: Test install collectors and enforcers setup
+        run: make install-test-collectors-enforcers-setup
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Test install collectors
-        run: make install-test-collectors
+      - name: Test install collectors and enforcers
+        run: make install-test-collectors-enforcers
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Test install collectors teardown
-        run: make install-test-collectors-teardown
+        run: install-test-collectors-enforcers-teardown
         if: steps.list-changed.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: lint install-test-grafeas-elasticsearch install-test-rode install-test-rode install-test-rode-ui
-.PHONY: install-test-collectors-setup install-test-collectors install-test-collectors-teardown
+.PHONY: install-test-collectors-enforcers-setup install-test-collectors-enforcers install-test-collectors-enforcers-teardown
 
 lint:
 	docker run --rm -v $$(pwd):/rode-charts/ -w /rode-charts quay.io/helmpack/chart-testing:v3.3.1 sh -c "helm repo add elastic https://helm.elastic.co; helm repo add rode https://rode.github.io/charts; helm repo update; ct lint --all"
@@ -13,14 +13,14 @@ install-test-rode:
 install-test-rode-ui:
 	ct install --target-branch main --charts charts/rode-ui --helm-extra-args --timeout=10m
 
-install-test-collectors-setup:
+install-test-collectors-enforcers-setup:
 	helm install -n rode-test --create-namespace rode-test ./charts/rode -f ./charts/rode/ci/test-values.yaml --wait
 
-install-test-collectors:
+install-test-collectors-enforcers:
 	ct install --target-branch main --excluded-charts rode,rode-ui,grafeas-elasticsearch --helm-extra-args --timeout=10m
 
-install-test-collectors-teardown:
+install-test-collectors-enforcers-teardown:
 	helm uninstall -n rode-test rode-test
 	kubectl delete namespace rode-test
 
-install-test: install-test-rode install-test-rode-ui install-test-grafeas-elasticsearch install-test-collectors-setup install-test-collectors install-test-collectors-teardown
+install-test: install-test-rode install-test-rode-ui install-test-grafeas-elasticsearch install-test-collectors-enforcers-setup install-test-collectors-enforcers install-test-collectors-enforcers-teardown

--- a/charts/enforcer-k8s/.helmignore
+++ b/charts/enforcer-k8s/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/enforcer-k8s/Chart.yaml
+++ b/charts/enforcer-k8s/Chart.yaml
@@ -1,23 +1,7 @@
 apiVersion: v2
 name: enforcer-k8s
-description: A Helm chart for Kubernetes
+description: A Helm chart for `enforcer-k8s`, which applies Rode policies against deployments to Kubernetes.
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 0.1.0

--- a/charts/enforcer-k8s/Chart.yaml
+++ b/charts/enforcer-k8s/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     email: rode@liatrio.com
 type: application
 version: 0.1.0
-appVersion: 0.1.0
+appVersion: 0.2.0

--- a/charts/enforcer-k8s/Chart.yaml
+++ b/charts/enforcer-k8s/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v2
 name: enforcer-k8s
 description: A Helm chart for `enforcer-k8s`, which applies Rode policies against deployments to Kubernetes.
-
+maintainers:
+  - name: Liatrio
+    email: rode@liatrio.com
 type: application
 version: 0.1.0
 appVersion: 0.1.0

--- a/charts/enforcer-k8s/Chart.yaml
+++ b/charts/enforcer-k8s/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: enforcer-k8s
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/charts/enforcer-k8s/ci/test-values.yaml
+++ b/charts/enforcer-k8s/ci/test-values.yaml
@@ -1,3 +1,4 @@
 rode:
   host: rode-test.rode-test.svc.cluster.local:50051
   insecure: true
+policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070

--- a/charts/enforcer-k8s/ci/test-values.yaml
+++ b/charts/enforcer-k8s/ci/test-values.yaml
@@ -1,0 +1,3 @@
+rode:
+  host: rode-test.rode-test.svc.cluster.local:50051
+  insecure: true

--- a/charts/enforcer-k8s/templates/_helpers.tpl
+++ b/charts/enforcer-k8s/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "enforcer-k8s.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "enforcer-k8s.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "enforcer-k8s.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "enforcer-k8s.labels" -}}
+helm.sh/chart: {{ include "enforcer-k8s.chart" . }}
+{{ include "enforcer-k8s.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "enforcer-k8s.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "enforcer-k8s.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "enforcer-k8s.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "enforcer-k8s.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/enforcer-k8s/templates/deployment.yaml
+++ b/charts/enforcer-k8s/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+  labels:
+    {{- include "enforcer-k8s.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "enforcer-k8s.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "enforcer-k8s.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "enforcer-k8s.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--tls-secret={{ .Values.webhook.secretName }}"
+            - "--policy-id={{ .Values.webhook.policyId }}"
+            - "--rode-host=rode.rode-demo.svc.cluster.local:50051"
+          ports:
+            - name: http
+              containerPort: 8001
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: 8001
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: 8001
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/enforcer-k8s/templates/deployment.yaml
+++ b/charts/enforcer-k8s/templates/deployment.yaml
@@ -37,18 +37,18 @@ spec:
             - "--rode-host=rode.rode-demo.svc.cluster.local:50051"
           ports:
             - name: http
-              containerPort: 8001
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               scheme: HTTPS
               path: /healthz
-              port: 8001
+              port: {{ .Values.service.port }}
           readinessProbe:
             httpGet:
               scheme: HTTPS
               path: /healthz
-              port: 8001
+              port: {{ .Values.service.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/enforcer-k8s/templates/deployment.yaml
+++ b/charts/enforcer-k8s/templates/deployment.yaml
@@ -29,12 +29,12 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" ($.Chart.AppVersion) )  }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--tls-secret={{ .Values.webhook.secretName }}"
-            - "--policy-id={{ .Values.webhook.policyId }}"
-            - "--rode-host=rode.rode-demo.svc.cluster.local:50051"
+            - "--tls-secret={{ .Values.tlsSecretName }}"
+            - "--policy-id={{ .Values.policyId }}"
+            - "--rode-host={{ .Values.rode.host }}"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/enforcer-k8s/templates/deployment.yaml
+++ b/charts/enforcer-k8s/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" ($.Chart.AppVersion) )  }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--tls-secret={{ .Values.tlsSecretName }}"
+            - "--tls-secret={{ .Release.Namespace }}/{{ .Values.tlsSecretName }}"
             - "--policy-id={{ .Values.policyId }}"
             - "--rode-host={{ .Values.rode.host }}"
           ports:

--- a/charts/enforcer-k8s/templates/rbac.yaml
+++ b/charts/enforcer-k8s/templates/rbac.yaml
@@ -1,4 +1,4 @@
-# necessary in order to read the secret containing the TLS config and any image pull secrets
+# necessary in order to read the secret containing the TLS config
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/enforcer-k8s/templates/rbac.yaml
+++ b/charts/enforcer-k8s/templates/rbac.yaml
@@ -1,0 +1,22 @@
+# necessary in order to read the secret containing the TLS config and any image pull secrets
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "enforcer-k8s.serviceAccountName" . }}
+    apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ include "enforcer-k8s.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/enforcer-k8s/templates/service.yaml
+++ b/charts/enforcer-k8s/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+  labels:
+    {{- include "enforcer-k8s.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "enforcer-k8s.selectorLabels" . | nindent 4 }}

--- a/charts/enforcer-k8s/templates/serviceaccount.yaml
+++ b/charts/enforcer-k8s/templates/serviceaccount.yaml
@@ -9,27 +9,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
----
-# necessary in order to read the secret containing the TLS config and any image pull secrets
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "enforcer-k8s.fullname" . }}
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "enforcer-k8s.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "enforcer-k8s.serviceAccountName" . }}
-    apiGroup: ""
-roleRef:
-  kind: Role
-  name: {{ include "enforcer-k8s.fullname" . }}
-  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/enforcer-k8s/templates/serviceaccount.yaml
+++ b/charts/enforcer-k8s/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "enforcer-k8s.serviceAccountName" . }}
+  labels:
+    {{- include "enforcer-k8s.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/enforcer-k8s/templates/serviceaccount.yaml
+++ b/charts/enforcer-k8s/templates/serviceaccount.yaml
@@ -9,4 +9,27 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+---
+# necessary in order to read the secret containing the TLS config and any image pull secrets
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "enforcer-k8s.serviceAccountName" . }}
+    apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ include "enforcer-k8s.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/enforcer-k8s/templates/webhook.yaml
+++ b/charts/enforcer-k8s/templates/webhook.yaml
@@ -1,0 +1,61 @@
+{{ $ca := genCA "svc-cat-ca" 3650 }}
+{{ $enforcerCn := printf "%s.%s.svc" .Release.Name .Release.Namespace }}
+{{ $enforcerCert := genSignedCert $enforcerCn nil (list $enforcerCn "localhost") 365 $ca }}
+
+{{ $caCrt := $ca.Cert | b64enc }}
+{{ $tlsCrt := $enforcerCert.Cert | b64enc }}
+{{ $tlsKey := $enforcerCert.Key | b64enc }}
+
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.webhook.secretName ) }}
+{{- if $secret }}
+  {{- $caCrt = index $secret.data "ca.crt" }}
+  {{- $tlsCrt = index $secret.data "tls.crt" }}
+  {{- $tlsKey = index $secret.data "tls.key" }}
+{{- end -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.webhook.secretName }}
+  labels:
+    app: {{ include "enforcer-k8s.fullname" . }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  ca.crt: {{ $caCrt }}
+  tls.crt: {{ $tlsCrt }}
+  tls.key: {{ $tlsKey }}
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: k8s-enforcer.rode.io
+webhooks:
+  - name: k8s-enforcer.rode.io
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    sideEffects: None
+    namespaceSelector:
+      matchExpressions:
+        - key: {{ .Values.webhook.namespaceLabel }}
+          operator: Exists
+    rules:
+      - apiGroups: [ "" ]
+        apiVersions: [ "v1" ]
+        operations: [ "CREATE", "UPDATE" ]
+        resources: [ "pods" ]
+        scope: "Namespaced"
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ include "enforcer-k8s.fullname" . }}
+        path: /
+        port: 8001
+      caBundle: {{ $caCrt }}
+    admissionReviewVersions: [ "v1" ]
+    timeoutSeconds: 5

--- a/charts/enforcer-k8s/templates/webhook.yaml
+++ b/charts/enforcer-k8s/templates/webhook.yaml
@@ -55,7 +55,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         name: {{ include "enforcer-k8s.fullname" . }}
         path: /
-        port: 8001
+        port: {{ .Values.service.port }}
       caBundle: {{ $caCrt }}
     admissionReviewVersions: [ "v1" ]
     timeoutSeconds: 5

--- a/charts/enforcer-k8s/templates/webhook.yaml
+++ b/charts/enforcer-k8s/templates/webhook.yaml
@@ -1,5 +1,5 @@
 {{ $ca := genCA "svc-cat-ca" 3650 }}
-{{ $enforcerCn := printf "%s.%s.svc" .Release.Name .Release.Namespace }}
+{{ $enforcerCn := printf "%s.%s.svc" (include "enforcer-k8s.fullname" .) .Release.Namespace }}
 {{ $enforcerCert := genSignedCert $enforcerCn nil (list $enforcerCn "localhost") 365 $ca }}
 
 {{ $caCrt := $ca.Cert | b64enc }}

--- a/charts/enforcer-k8s/templates/webhook.yaml
+++ b/charts/enforcer-k8s/templates/webhook.yaml
@@ -6,7 +6,7 @@
 {{ $tlsCrt := $enforcerCert.Cert | b64enc }}
 {{ $tlsKey := $enforcerCert.Key | b64enc }}
 
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.webhook.secretName ) }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.tlsSecretName ) }}
 {{- if $secret }}
   {{- $caCrt = index $secret.data "ca.crt" }}
   {{- $tlsCrt = index $secret.data "tls.crt" }}
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.webhook.secretName }}
+  name: {{ .Values.tlsSecretName }}
   labels:
     app: {{ include "enforcer-k8s.fullname" . }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
@@ -42,7 +42,7 @@ webhooks:
     sideEffects: None
     namespaceSelector:
       matchExpressions:
-        - key: {{ .Values.webhook.namespaceLabel }}
+        - key: {{ .Values.namespaceLabel }}
           operator: Exists
     rules:
       - apiGroups: [ "" ]

--- a/charts/enforcer-k8s/values.yaml
+++ b/charts/enforcer-k8s/values.yaml
@@ -1,0 +1,38 @@
+replicaCount: 1
+
+image:
+  repository: enforcer-k8s
+  pullPolicy: Never
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8001
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+webhook:
+  secretName: enforcer-k8s
+  namespaceLabel: enforcer-k8s
+  policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070

--- a/charts/enforcer-k8s/values.yaml
+++ b/charts/enforcer-k8s/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: enforcer-k8s
-  pullPolicy: Never
+  pullPolicy: IfNotPresent
   tag: ""
 
 imagePullSecrets: []
@@ -32,7 +32,9 @@ tolerations: []
 
 affinity: {}
 
-webhook:
-  secretName: enforcer-k8s
-  namespaceLabel: enforcer-k8s
-  policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070
+rode:
+  host: rode:50051
+
+tlsSecretName: enforcer-k8s
+namespaceLabel: enforcer-k8s
+policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070

--- a/charts/enforcer-k8s/values.yaml
+++ b/charts/enforcer-k8s/values.yaml
@@ -38,4 +38,4 @@ rode:
 tlsSecretName: enforcer-k8s
 namespaceLabel: enforcer-k8s
 # set policyId to the policy that should be enforced for all pods in the namespace specified by namespaceLabel
-#policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070
+# policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070

--- a/charts/enforcer-k8s/values.yaml
+++ b/charts/enforcer-k8s/values.yaml
@@ -37,4 +37,5 @@ rode:
 
 tlsSecretName: enforcer-k8s
 namespaceLabel: enforcer-k8s
-policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070
+# set policyId to the policy that should be enforced for all pods in the namespace specified by namespaceLabel
+#policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070

--- a/charts/enforcer-k8s/values.yaml
+++ b/charts/enforcer-k8s/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: enforcer-k8s
+  repository: "ghcr.io/rode/enforcer-k8s"
   pullPolicy: IfNotPresent
   tag: ""
 


### PR DESCRIPTION
Takes the chart from https://github.com/rode/enforcer-k8s/pull/1, adds RBAC for getting secrets (may need to expand this later, depending on how we handle image pull secrets), and cleans it up a bit to match the other charts. 