### PR TITLE
[rode-collector-harbor] bump app version

### DIFF
--- a/charts/rode-collector-harbor/Chart.yaml
+++ b/charts/rode-collector-harbor/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
   - name: Liatrio
     email: rode@liatrio.com
 type: application
-version: 0.0.3
-appVersion: v0.0.3
+version: 0.1.0
+appVersion: v0.1.0


### PR DESCRIPTION
I fixed a comment in this chart in #58 and didn't realize it would try to cut a release.  this should fix the release pipeline.