### PR TITLE
[enforcer-k8s] Use policy groups, update rbac permissions

### DIFF
--- a/charts/enforcer-k8s/Chart.yaml
+++ b/charts/enforcer-k8s/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
     email: rode@liatrio.com
 type: application
 version: 0.2.0
-appVersion: 0.3.0
+appVersion: 0.4.0

--- a/charts/enforcer-k8s/ci/test-values.yaml
+++ b/charts/enforcer-k8s/ci/test-values.yaml
@@ -1,4 +1,4 @@
 rode:
   host: rode-test.rode-test.svc.cluster.local:50051
   insecure: true
-policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070
+policyGroup: my-policy-group

--- a/charts/enforcer-k8s/templates/deployment.yaml
+++ b/charts/enforcer-k8s/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - "--port={{ .Values.service.port }}"
             - "--debug={{ .Values.debug }}"
             - "--tls-secret={{ .Release.Namespace }}/{{ .Values.tlsSecretName }}"
-            - "--policy-id={{ .Values.policyId }}"
+            - "--policy-group={{ .Values.policyGroup }}"
             - "--rode-host={{ .Values.rode.host }}"
             - "--rode-insecure={{ .Values.rode.insecure }}"
             - "--registry-insecure-skip-verify={{ .Values.registryInsecureSkipVerify }}"

--- a/charts/enforcer-k8s/templates/rbac.yaml
+++ b/charts/enforcer-k8s/templates/rbac.yaml
@@ -1,4 +1,5 @@
-# necessary in order to read the secret containing the TLS config
+{{- if .Values.rbac.create }}
+# The Role is necessary in order to read the TLS secret within the namespace the enforcer is deployed to
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -20,3 +21,35 @@ roleRef:
   kind: Role
   name: {{ include "enforcer-k8s.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+---
+# Unfortunately, the ClusterRole is also necessary in order to fetch imagePullSecrets for each pod in order to query the registry API
+# This cluster-wide access to secrets can be trimmed by specifying `rbac.imagePullSecretNames`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    {{- with .Values.rbac.imagePullSecretNames }}
+    resourceNames:
+      {{- range .}}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "enforcer-k8s.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "enforcer-k8s.serviceAccountName" . }}
+    apiGroup: ""
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "enforcer-k8s.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/enforcer-k8s/templates/webhook.yaml
+++ b/charts/enforcer-k8s/templates/webhook.yaml
@@ -58,4 +58,4 @@ webhooks:
         port: {{ .Values.service.port }}
       caBundle: {{ $caCrt }}
     admissionReviewVersions: [ "v1" ]
-    timeoutSeconds: 5
+    timeoutSeconds: 10

--- a/charts/enforcer-k8s/values.yaml
+++ b/charts/enforcer-k8s/values.yaml
@@ -14,6 +14,13 @@ serviceAccount:
   annotations: {}
   name: ""
 
+rbac:
+  create: true
+
+  # rbac.imagePullSecretNames can be used to restrict the enforcer's cluster-wide access to secrets to a particular list of names
+#  imagePullSecretNames:
+#    - harbor
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -44,5 +51,6 @@ namespaceLabel: enforcer-k8s
 kubernetes:
   inCluster: true
   configFile: ""
-# set policyId to the policy that should be enforced for all pods in the namespace specified by namespaceLabel
-# policyId: 0bc9541d-2663-44e0-a8ee-d14c7a073070
+
+# set policyGroup to the policy group that should be evaluated against for all pods in the namespace specified by namespaceLabel
+policyGroup: my-policy-group


### PR DESCRIPTION
- update chart to use policy group instead of policy ID
- bump webhook timeout from 5 to 10 seconds
- update rbac to allow enforcer to query clusterwide secrets with optional resource name limitation
- bump to v0.4.0