### PR TITLE
[rode] Allow for gRPC and HTTP ingress

### DIFF
--- a/charts/rode/Chart.yaml
+++ b/charts/rode/Chart.yaml
@@ -4,7 +4,7 @@ name: rode
 maintainers:
   - name: Liatrio
     email: rode@liatrio.com
-version: 0.3.3
+version: 0.4.0
 appVersion: 0.14.7
 dependencies:
   - name: rode-ui

--- a/charts/rode/templates/ingress.yaml
+++ b/charts/rode/templates/ingress.yaml
@@ -1,33 +1,35 @@
-{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rode.name" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $root := .}}
+{{- range $ingressType, $ingressConfig := .Values.ingress }}
+{{- if $ingressConfig.enabled -}}
+{{- if semverCompare ">=1.14-0" $root.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+  {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-{{ $ingressType }}
   labels:
-    {{- include "rode.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- include "rode.labels" $root | nindent 4 }}
+  {{- with $ingressConfig.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tls }}
+  {{- if $ingressConfig.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range $ingressConfig.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
-        {{- end }}
+      {{- end }}
       secretName: {{ .secretName }}
-    {{- end }}
+  {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range $ingressConfig.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -36,6 +38,8 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-          {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}
+---
+{{- end }}

--- a/charts/rode/values.yaml
+++ b/charts/rode/values.yaml
@@ -59,18 +59,22 @@ service:
   port: 50051
 
 ingress:
-  enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts: []
-    # - host: chart-example.local
-    #   paths:
-    #     - /
-  tls: []
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  grpc:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+  http:
+    enabled: false
+    annotations: {}
+    hosts: []
+#       - host: chart-example.local
+#         paths:
+#           - /
+    tls: []
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
 
 nodeSelector: {}
 


### PR DESCRIPTION
AIUI we need two separate ingress for gRPC and HTTP, since the gRPC proxy behavior is controlled by an annotation. 
This changes the Rode Helm chart to allow for two ingresses with different configuration. I called them `http`/`grpc` for convenience, but there's nothing specific to the protocols besides the name.  

I tested this out locally using the Rode demo and was able to hit the HTTP ingress (with `curl`) and gRPC ingress (with `grpcurl` and the Rode client). 