### PR TITLE
Add configuration options to enable gRPC ingress for build-collector

### DIFF
--- a/charts/rode-collector-build/Chart.yaml
+++ b/charts/rode-collector-build/Chart.yaml
@@ -5,5 +5,5 @@ maintainers:
   - name: Liatrio
     email: rode@liatrio.com
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: 0.3.3

--- a/charts/rode-collector-build/templates/ingress.yaml
+++ b/charts/rode-collector-build/templates/ingress.yaml
@@ -1,24 +1,26 @@
-{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rode-collector-build.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $root := .}}
+{{- range $ingressType, $ingressConfig := .Values.ingress }}
+{{- if $ingressConfig.enabled -}}
+{{- if semverCompare ">=1.14-0" $root.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-{{ $ingressType }}
   labels:
-    {{- include "rode-collector-build.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- include "rode-collector-build.labels" $root | nindent 4 }}
+  {{- with $ingressConfig.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tls }}
+  {{- if $ingressConfig.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range $ingressConfig.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -27,7 +29,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range $ingressConfig.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -38,4 +40,6 @@ spec:
               servicePort: {{ $svcPort }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}
+---
+{{- end }}

--- a/charts/rode-collector-build/values.yaml
+++ b/charts/rode-collector-build/values.yaml
@@ -34,12 +34,18 @@ rode:
       enabled: false
 
 ingress:
-  enabled: false
-  annotations: {}
-  hosts:
-    - host: chart-example.local
-      paths: []
-  tls: []
+  grpc:
+    enabled: false
+    annotations: {}
+    hosts: []
+    tls: []
+  http:
+    enabled: false
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths: []
+    tls: []
 
 resources:
   limits:


### PR DESCRIPTION
Adds configuration options to allow build-collector to be configured with a gRPC ingress to work with existing GitHub Actions.

This change is based on #92 